### PR TITLE
correct attention_dropout behaviour

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -257,7 +257,7 @@ class TransformerDecoder(DecoderBase):
             opt.self_attn_type,
             opt.dropout[0] if type(opt.dropout) is list else opt.dropout,
             opt.attention_dropout[0] if type(opt.attention_dropout)
-            is list else opt.dropout,
+            is list else opt.attention_dropout,
             embeddings,
             opt.max_relative_positions,
             opt.aan_useffn,


### PR DESCRIPTION
looks like a copy paste error. The transformer encoder doesn't fall back to dropout if attention_dropout is not a list.